### PR TITLE
Remove quotes around history limit

### DIFF
--- a/job/templates/CronJob.yaml
+++ b/job/templates/CronJob.yaml
@@ -17,10 +17,10 @@ spec:
   concurrencyPolicy: "{{ $languageValues.concurrencyPolicy }}"
   {{- end }}
   {{- if $languageValues.successfulJobsHistoryLimit }}
-  successfulJobsHistoryLimit: "{{ $languageValues.successfulJobsHistoryLimit }}"
+  successfulJobsHistoryLimit: {{ $languageValues.successfulJobsHistoryLimit }}
   {{- end }}
   {{- if $languageValues.failedJobsHistoryLimit }}
-  failedJobsHistoryLimit: "{{ $languageValues.failedJobsHistoryLimit }}"
+  failedJobsHistoryLimit: {{ $languageValues.failedJobsHistoryLimit }}
   {{- end }}
   {{- if $languageValues.suspend }}
   suspend: {{ $languageValues.suspend }}


### PR DESCRIPTION
Got a build that failed with:
```
Error: 1 error occurred:

* CronJob in version "v1" cannot be handled as a CronJob: json: cannot unmarshal string into Go struct field CronJobSpec.spec.failedJobsHistoryLimit of type int32
```

https://github.com/hmcts/tax-tribunals-datacapture/pull/12
https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_j_to_z%2Ftax-tribunals-datacapture/detail/PR-12/19/pipeline/

Untested but sounds sensible?