### PR TITLE
Allow use of "suspend: true" even on ActiveCronCluster cluster

### DIFF
--- a/job/templates/CronJob.yaml
+++ b/job/templates/CronJob.yaml
@@ -22,7 +22,7 @@ spec:
   startingDeadlineSeconds: {{ int $languageValues.startingDeadlineSeconds }}
   suspend: {{ int $languageValues.suspend }}
   {{- else }}
-  {{ if eq $languageValues.suspend true }}
+  {{ if $languageValues.suspend }}
   suspend: true
   startingDeadlineSeconds: 5
   {{- else }}

--- a/job/templates/CronJob.yaml
+++ b/job/templates/CronJob.yaml
@@ -22,7 +22,7 @@ spec:
   startingDeadlineSeconds: {{ int $languageValues.startingDeadlineSeconds }}
   suspend: {{ int $languageValues.suspend }}
   {{- else }}
-  {{ if eq .$languageValues.suspend true }}
+  {{ if eq $languageValues.suspend true }}
   suspend: true
   startingDeadlineSeconds: 5
   {{- else }}

--- a/job/templates/CronJob.yaml
+++ b/job/templates/CronJob.yaml
@@ -20,7 +20,7 @@ spec:
   schedule: "{{ $languageValues.schedule }}"
   {{- if $disableActiveClusterCheck }}
   startingDeadlineSeconds: {{ int $languageValues.startingDeadlineSeconds }}
-  suspend: {{ int $languageValues.suspend }}
+  suspend: {{ $languageValues.suspend }}
   {{- else }}
   {{ if $languageValues.suspend }}
   suspend: true

--- a/job/templates/CronJob.yaml
+++ b/job/templates/CronJob.yaml
@@ -20,7 +20,11 @@ spec:
   schedule: "{{ $languageValues.schedule }}"
   {{- if $disableActiveClusterCheck }}
   startingDeadlineSeconds: {{ int $languageValues.startingDeadlineSeconds }}
-  suspend: false
+  suspend: {{ int $languageValues.suspend }}
+  {{- else }}
+  {{ if eq .$languageValues.suspend true }}
+  suspend: true
+  startingDeadlineSeconds: 5
   {{- else }}
   suspend: {{ not $activeCronCluster }}
   startingDeadlineSeconds: {{ $activeCronCluster | ternary $languageValues.startingDeadlineSeconds 5 }}

--- a/job/templates/CronJob.yaml
+++ b/job/templates/CronJob.yaml
@@ -29,6 +29,7 @@ spec:
   suspend: {{ not $activeCronCluster }}
   startingDeadlineSeconds: {{ $activeCronCluster | ternary $languageValues.startingDeadlineSeconds 5 }}
   {{- end }}
+  {{- end }}
   {{- if $languageValues.concurrencyPolicy }}
   concurrencyPolicy: "{{ $languageValues.concurrencyPolicy }}"
   {{- end }}


### PR DESCRIPTION
### Change description ###

* A bug was found where a team tried to temporarily suspend a scheduled cronJob using the "suspend: true" flag and inheriting 2.0.0 release that has logic for ActiveCronCluster flag
* The cronJob wasn't suspending as the logic in this release ONLY checks for the ActiveCronCluster to determine if suspend is set to either true or false
* This commit brings in logic to allow suspensions using the "suspend: true" parameter do teams don't need to remove cronJob RD's from Kustomization to achieve a pseudo-suspend


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
