### PR TITLE
DTSPO-33906: close helm-unittest coverage gaps, bump chart-library

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ resources:
   repositories:
   - repository: cnp-azuredevops-libraries
     type: github
+    ref: refs/heads/helm_v4_validation
     name: hmcts/cnp-azuredevops-libraries
     endpoint: 'hmcts'
 

--- a/job/Chart.yaml
+++ b/job/Chart.yaml
@@ -10,5 +10,5 @@ keywords:
   - CronJob
 dependencies:
   - name: library
-    version: 2.2.2
+    version: 2.3.0
     repository: oci://hmctsprod.azurecr.io/helm

--- a/job/templates/CronJob.yaml
+++ b/job/templates/CronJob.yaml
@@ -15,7 +15,7 @@
 ---
 apiVersion: batch/v1
 kind: CronJob
-{{ include "hmcts.metadata.v2" .}}
+{{ include "hmcts.metadata.v3" .}}
 spec:
   schedule: "{{ $languageValues.schedule }}"
   {{- if $disableActiveClusterCheck }}

--- a/job/templates/Job.yaml
+++ b/job/templates/Job.yaml
@@ -7,6 +7,6 @@
 ---
 apiVersion: batch/v1
 kind: Job
-{{ include "hmcts.metadata.v2" .}}
+{{ include "hmcts.metadata.v3" .}}
 {{ include "job.spec.v2" .}}
   {{- end}}

--- a/job/templates/_jobspec.tpl
+++ b/job/templates/_jobspec.tpl
@@ -16,5 +16,5 @@ spec:
   {{- if $languageValues.ttlSecondsAfterFinished }}
   ttlSecondsAfterFinished: {{ $languageValues.ttlSecondsAfterFinished }}
   {{- end }}
-{{ include "hmcts.podtemplate.v6.tpl" . | indent 2 -}}
+{{ include "hmcts.podtemplate.v7.tpl" . | indent 2 -}}
 {{- end -}}

--- a/job/templates/configmap.yaml
+++ b/job/templates/configmap.yaml
@@ -1,1 +1,1 @@
-{{- template "hmcts.configmap.v2.tpl" . -}}
+{{- template "hmcts.configmap.v3.tpl" . -}}

--- a/job/templates/secretproviderclass.yaml
+++ b/job/templates/secretproviderclass.yaml
@@ -1,1 +1,1 @@
-{{- template "hmcts.secretproviderclass.v5.tpl" . -}}
+{{- template "hmcts.secretproviderclass.v6.tpl" . -}}

--- a/job/tests/unit-tests/cronjob_test.yaml
+++ b/job/tests/unit-tests/cronjob_test.yaml
@@ -30,8 +30,7 @@ tests:
       kind: CronJob
       schedule: "*/5 * * * *"
       startingDeadlineSeconds: 1200
-      # top-level disableActiveClusterCheck takes precedence over global (see CronJob.yaml),
-      # so it must be overridden here too - ci-values-minimal.yaml sets it true by default
+      # top-level disableActiveClusterCheck wins over global, override here too (see CronJob.yaml)
       disableActiveClusterCheck: false
       global:
         activeCronCluster: false
@@ -50,8 +49,6 @@ tests:
       kind: CronJob
       schedule: "*/5 * * * *"
       startingDeadlineSeconds: 1200
-      # top-level disableActiveClusterCheck takes precedence over global (see CronJob.yaml),
-      # so it must be overridden here too - ci-values-minimal.yaml sets it true by default
       disableActiveClusterCheck: false
       global:
         activeCronCluster: true
@@ -71,8 +68,6 @@ tests:
       schedule: "*/5 * * * *"
       startingDeadlineSeconds: 1200
       suspend: true
-      # top-level disableActiveClusterCheck takes precedence over global (see CronJob.yaml),
-      # so it must be overridden here too - ci-values-minimal.yaml sets it true by default
       disableActiveClusterCheck: false
       global:
         activeCronCluster: true
@@ -123,8 +118,7 @@ tests:
       startingDeadlineSeconds: 1200
       disableActiveClusterCheck: true
       suspend: false
-      # values.yaml defaults concurrencyPolicy to "Forbid", so it must be explicitly
-      # cleared here to genuinely exercise the absent branch
+      # defaults to "Forbid" in values.yaml, must be cleared to hit the absent branch
       concurrencyPolicy: null
     asserts:
       - notExists:
@@ -189,9 +183,7 @@ tests:
       schedule: "*/5 * * * *"
       startingDeadlineSeconds: 900
       suspend: false
-      # explicitly unset the top-level key (ci-values-minimal.yaml forces it true by default)
-      # so this test genuinely exercises the fallback to global, rather than passing
-      # coincidentally because the top-level default was already true
+      # unset top-level (defaults true in ci-values-minimal.yaml) to genuinely test the fallback
       disableActiveClusterCheck: null
       global:
         disableActiveClusterCheck: true

--- a/job/tests/unit-tests/cronjob_test.yaml
+++ b/job/tests/unit-tests/cronjob_test.yaml
@@ -30,6 +30,9 @@ tests:
       kind: CronJob
       schedule: "*/5 * * * *"
       startingDeadlineSeconds: 1200
+      # top-level disableActiveClusterCheck takes precedence over global (see CronJob.yaml),
+      # so it must be overridden here too - ci-values-minimal.yaml sets it true by default
+      disableActiveClusterCheck: false
       global:
         activeCronCluster: false
         disableActiveClusterCheck: false
@@ -47,6 +50,9 @@ tests:
       kind: CronJob
       schedule: "*/5 * * * *"
       startingDeadlineSeconds: 1200
+      # top-level disableActiveClusterCheck takes precedence over global (see CronJob.yaml),
+      # so it must be overridden here too - ci-values-minimal.yaml sets it true by default
+      disableActiveClusterCheck: false
       global:
         activeCronCluster: true
         disableActiveClusterCheck: false
@@ -65,6 +71,9 @@ tests:
       schedule: "*/5 * * * *"
       startingDeadlineSeconds: 1200
       suspend: true
+      # top-level disableActiveClusterCheck takes precedence over global (see CronJob.yaml),
+      # so it must be overridden here too - ci-values-minimal.yaml sets it true by default
+      disableActiveClusterCheck: false
       global:
         activeCronCluster: true
         disableActiveClusterCheck: false
@@ -165,6 +174,10 @@ tests:
       schedule: "*/5 * * * *"
       startingDeadlineSeconds: 900
       suspend: false
+      # explicitly unset the top-level key (ci-values-minimal.yaml forces it true by default)
+      # so this test genuinely exercises the fallback to global, rather than passing
+      # coincidentally because the top-level default was already true
+      disableActiveClusterCheck: null
       global:
         disableActiveClusterCheck: true
     asserts:

--- a/job/tests/unit-tests/cronjob_test.yaml
+++ b/job/tests/unit-tests/cronjob_test.yaml
@@ -115,6 +115,21 @@ tests:
           path: spec.concurrencyPolicy
           value: Forbid
 
+  - it: concurrencyPolicy is absent when not set
+    set:
+      image: hmctspublic.azurecr.io/test/app:latest
+      kind: CronJob
+      schedule: "*/5 * * * *"
+      startingDeadlineSeconds: 1200
+      disableActiveClusterCheck: true
+      suspend: false
+      # values.yaml defaults concurrencyPolicy to "Forbid", so it must be explicitly
+      # cleared here to genuinely exercise the absent branch
+      concurrencyPolicy: null
+    asserts:
+      - notExists:
+          path: spec.concurrencyPolicy
+
   - it: successfulJobsHistoryLimit is rendered when set
     set:
       image: hmctspublic.azurecr.io/test/app:latest

--- a/job/tests/unit-tests/cronjob_test.yaml
+++ b/job/tests/unit-tests/cronjob_test.yaml
@@ -157,3 +157,40 @@ tests:
     asserts:
       - notExists:
           path: spec.failedJobsHistoryLimit
+
+  - it: disableActiveClusterCheck falls back to global value when not set locally
+    set:
+      image: hmctspublic.azurecr.io/test/app:latest
+      kind: CronJob
+      schedule: "*/5 * * * *"
+      startingDeadlineSeconds: 900
+      suspend: false
+      global:
+        disableActiveClusterCheck: true
+    asserts:
+      - equal:
+          path: spec.suspend
+          value: false
+      - equal:
+          path: spec.startingDeadlineSeconds
+          value: 900
+
+  - it: language values override kind to CronJob while unrelated top-level values still apply
+    set:
+      image: hmctspublic.azurecr.io/test/app:latest
+      kind: Job
+      schedule: "*/5 * * * *"
+      startingDeadlineSeconds: 1200
+      disableActiveClusterCheck: true
+      suspend: false
+      language: java
+      java:
+        kind: CronJob
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.schedule
+          value: "*/5 * * * *"

--- a/job/tests/unit-tests/job_test.yaml
+++ b/job/tests/unit-tests/job_test.yaml
@@ -44,3 +44,29 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: language values override kind, hiding Job when the language override sets CronJob
+    set:
+      image: hmctspublic.azurecr.io/test/app:latest
+      kind: Job
+      schedule: "*/5 * * * *"
+      language: java
+      java:
+        kind: CronJob
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: language values override kind, rendering Job when the language override sets Job
+    set:
+      image: hmctspublic.azurecr.io/test/app:latest
+      kind: CronJob
+      schedule: "*/5 * * * *"
+      language: java
+      java:
+        kind: Job
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job

--- a/job/tests/unit-tests/jobspec_test.yaml
+++ b/job/tests/unit-tests/jobspec_test.yaml
@@ -56,3 +56,20 @@ tests:
     asserts:
       - notExists:
           path: spec.backoffLimit
+
+  - it: language values override backoffLimit while unset top-level fields still fall back
+    set:
+      image: hmctspublic.azurecr.io/test/app:latest
+      kind: Job
+      backoffLimit: 6
+      ttlSecondsAfterFinished: 120
+      language: java
+      java:
+        backoffLimit: 2
+    asserts:
+      - equal:
+          path: spec.backoffLimit
+          value: 2
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 120


### PR DESCRIPTION



### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
